### PR TITLE
Feat reform ext dir

### DIFF
--- a/createlinks/modules/cust.py
+++ b/createlinks/modules/cust.py
@@ -16,13 +16,13 @@ logger = logging.getLogger(__name__)
 class ExternalIDNotFoundException(Exception):
     pass
 
-class CustomerIDMalformedException(Exception):
+class MalformedCustomerIDException(Exception):
     def __init__(self, customer, sample_id):
         self.customer = customer
         self.sample_id = sample_id
 
     def __str__(self):
-        return self.repr("Customer name '{}' for '{}' was not found in LIMS".format(self.customer, self.sample_id))
+        return repr("Customer name '{}' for '{}' was not found in LIMS".format(self.customer, self.sample_id))
 
 def _connect_lims():
     """ Connects to LIMS and returns Lims object
@@ -77,10 +77,10 @@ def get_cust_name(internal_id):
         customer = sample.udf('customer')
         customer = customer.lower()
         if re.match(r'cust\d{3}', cust_name):
-            raise CustomerIDMalformedException(customer, internal_id)
+            raise MalformedCustomerIDException(customer, internal_id)
         return customer
     except:
-        raise CustomerIDMalformedException(customer, internal_id)
+        raise MalformedCustomerIDException(customer, internal_id)
 
     return None
 

--- a/createlinks/modules/cust.py
+++ b/createlinks/modules/cust.py
@@ -59,7 +59,7 @@ def get_internal_id(external_id):
     return None
 
 def get_cust_name(internal_id):
-    """ Looks up the customer name from an external ID in LIMS
+    """ Looks up the customer name from an internal ID in LIMS
 
     Args:
         internal_id (str): the internal sample ID
@@ -85,6 +85,15 @@ def get_cust_name(internal_id):
     return None
 
 def make_link(source, dest, link_type='hard'):
+    """ Create a hard or soft link
+
+    Args:
+        source (str): path to the source file
+        dest (str): path to the destination file
+        link_type (str, default hard): hard|soft link
+
+    Returns: None
+    """
     # remove previous link
     try:
         os.remove(dest)
@@ -98,6 +107,7 @@ def make_link(source, dest, link_type='hard'):
             os.symlink(source, dest)
         else:
             logger.info("ln {} {} ...".format(os.path.realpath(source), dest))
+            # unlink before making hardlink
             os.link(os.path.realpath(source), dest)
     except:
         logger.error("Can't create symlink from {} to {}".format(source, dest))
@@ -119,6 +129,16 @@ def setup_logging(level='INFO'):
     return root_logger
 
 def cust_links(fastq_full_file_name, outdir):
+    """ Based on an input file name:
+        * determine what format the file name has
+        * pick out sample name, read direction, lane, flowcell, date, index
+        * link the input file to the outdir renamed to fit MIP naming scheme.
+
+    Args:
+        fastq_full_file_name (str): full path to the input file
+        outdir (str): the path to the outdir
+
+    """
 
     logger.info('Version: {} {}'.format(__file__, __version__))
     #outdir = '/mnt/hds/proj/bioinfo/EXTERNAL/'

--- a/createlinks/modules/cust.py
+++ b/createlinks/modules/cust.py
@@ -20,7 +20,9 @@ class CustomerIDMalformedException(Exception):
     def __init__(self, customer, sample_id):
         self.customer = customer
         self.sample_id = sample_id
-        logger.error("Customer name '{}' for '{}' was not found in LIMS".format(customer, sample_id))
+
+    def __str__(self):
+        return self.repr("Customer name '{}' for '{}' was not found in LIMS".format(self.customer, self.sample_id))
 
 def _connect_lims():
     """ Connects to LIMS and returns Lims object

--- a/createlinks/modules/cust.py
+++ b/createlinks/modules/cust.py
@@ -169,7 +169,6 @@ def cust_links(fastq_full_file_name, outdir):
     out_file_name = '_'.join([lane, date, FC, internal_id, index, direction])
     out_file_name = '{}.{}'.format(out_file_name, extension)
 
-    import ipdb; ipdb.set_trace()
     customer = get_cust_name(internal_id)
 
     # make out dir

--- a/createlinks/modules/cust.py
+++ b/createlinks/modules/cust.py
@@ -17,7 +17,10 @@ class ExternalIDNotFoundException(Exception):
     pass
 
 class CustomerIDMalformedException(Exception):
-    logger.error("Customer name '{}' for '{}' was not found in LIMS".format(customer, internal_id))
+    def __init__(self, customer, sample_id):
+        self.customer = customer
+        self.sample_id = sample_id
+        logger.error("Customer name '{}' for '{}' was not found in LIMS".format(customer, sample_id))
 
 def _connect_lims():
     """ Connects to LIMS and returns Lims object

--- a/createlinks/modules/cust.py
+++ b/createlinks/modules/cust.py
@@ -22,7 +22,7 @@ class MalformedCustomerIDException(Exception):
         self.sample_id = sample_id
 
     def __str__(self):
-        return repr("Customer name '{}' for '{}' was not found in LIMS".format(self.customer, self.sample_id))
+        return repr("Customer name '{}' for '{}' is not correctly formatted in LIMS".format(self.customer, self.sample_id))
 
 def _connect_lims():
     """ Connects to LIMS and returns Lims object
@@ -74,9 +74,9 @@ def get_cust_name(internal_id):
     try:
         sample = Sample(lims, id=internal_id)
 
-        customer = sample.udf('customer')
+        customer = sample.udf['customer']
         customer = customer.lower()
-        if re.match(r'cust\d{3}', cust_name):
+        if not re.match(r'cust\d{3}', customer):
             raise MalformedCustomerIDException(customer, internal_id)
         return customer
     except:
@@ -169,6 +169,7 @@ def cust_links(fastq_full_file_name, outdir):
     out_file_name = '_'.join([lane, date, FC, internal_id, index, direction])
     out_file_name = '{}.{}'.format(out_file_name, extension)
 
+    import ipdb; ipdb.set_trace()
     customer = get_cust_name(internal_id)
 
     # make out dir

--- a/createlinks/modules/ext.py
+++ b/createlinks/modules/ext.py
@@ -115,7 +115,7 @@ def get_index(fastq_file_name):
         while not line.startswith('@'):
             line = f.readline().rstrip()
 
-        index = line.split(':')[9]
+        index = line.split(':')[-1]
         return index
 
 def setup_logging(level='INFO'):

--- a/scripts/checkforextsamples.bash
+++ b/scripts/checkforextsamples.bash
@@ -9,8 +9,15 @@ log() {
 
 cd /mnt/hds/proj/bioinfo/git/kenny/data-delivery/
 for SAMPLE in ${EXTDIR}/*; do
+    DIR=$(dirname $SAMPLE)
+    if [[ -e ${DIR}/delivered.txt ]]; then
+        log "Delivered: $SAMPLE"
+        continue
+    fi
+
     log "Found: $SAMPLE"
 
     python -m createlinks.cli ext $SAMPLE
+    date +'%Y%m%d%H%M%S' > ${DIR}/delivered.txt
 done
 cd -

--- a/scripts/checkforextsamples.bash
+++ b/scripts/checkforextsamples.bash
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 EXTDIR=${1?'Please provide the EXTERNAL directory'}
 
 log() {
@@ -8,9 +10,9 @@ log() {
 }
 
 cd /mnt/hds/proj/bioinfo/git/kenny/data-delivery/
-for SAMPLE in ${EXTDIR}/*; do
+for SAMPLE in ${EXTDIR}/cust*/*; do
     DIR=$(dirname $SAMPLE)
-    if [[ -e ${DIR}/delivered.txt ]]; then
+    if [[ -e ${SAMPLE}/delivered.txt ]]; then
         log "Delivered: $SAMPLE"
         continue
     fi
@@ -18,6 +20,6 @@ for SAMPLE in ${EXTDIR}/*; do
     log "Found: $SAMPLE"
 
     python -m createlinks.cli ext $SAMPLE
-    date +'%Y%m%d%H%M%S' > ${DIR}/delivered.txt
+    date +'%Y%m%d%H%M%S' > ${SAMPLE}/delivered.txt
 done
 cd -


### PR DESCRIPTION
Go from a sample centric dir structure to a cust/sample structure. Also add a way to skip creating links for fastq files that already have been linked.

Haven't tested this tho ;)