### PR TITLE
Add a project log when importing to EXTERNAL

### DIFF
--- a/deliver/modules/cust.py
+++ b/deliver/modules/cust.py
@@ -141,7 +141,8 @@ def setup_logging(level='INFO', delayed_logging=False):
     return root_logger
 
 def setup_logfile(output_file):
-    """TODO: Docstring for write_log.
+    """Sets up the log file by replacing the MemoryHandler from the logger
+    with a FileHandler.
 
     Args:
         output_file (str): The path to the target log file.

--- a/scripts/checkforextsamples.bash
+++ b/scripts/checkforextsamples.bash
@@ -19,7 +19,7 @@ for SAMPLE in ${EXTDIR}/cust*/*; do
 
     log "Found: $SAMPLE"
 
-    python -m deliver.cli ext $SAMPLE
+    python -m deliver.cli ext $SAMPLE >> ${SAMPLE}/project.log
     date +'%Y%m%d%H%M%S' > ${SAMPLE}/delivered.txt
 done
 cd -


### PR DESCRIPTION
Append to a project log when importing to MIP_ANALYSIS.

I know I know. Logging and project logs. Difficult topic.

When importing external samples into `EXTERNAL`, this PR will add a project log at the `EXTERNAL/custXXX/$sample/` level. Specifically, this adds a buffer that will be written to a `project.log` at the scripts end.